### PR TITLE
API updates for #41

### DIFF
--- a/scheduler_msgs/CHANGELOG.rst
+++ b/scheduler_msgs/CHANGELOG.rst
@@ -6,5 +6,10 @@ Change history
 
  * Initial version of an experimental scheduler message package for
    Hydro (`#27`_).
+ * Updates due to experience with prototype implementation (`#41`_):
+   - add new SchedulerRequests message type
+   - deprecate AllocateResources and SchedulerFeedback
+   - add new RESERVED status to Request message
 
 .. _`#27`: https://github.com/robotics-in-concert/rocon_msgs/pull/27
+.. _`#41`: https://github.com/robotics-in-concert/rocon_msgs/issue/41

--- a/scheduler_msgs/CHANGELOG.rst
+++ b/scheduler_msgs/CHANGELOG.rst
@@ -10,6 +10,7 @@ Change history
    - add new SchedulerRequests message type
    - deprecate AllocateResources and SchedulerFeedback
    - add new RESERVED status to Request message
+   - add hold_time duration to Request message
 
 .. _`#27`: https://github.com/robotics-in-concert/rocon_msgs/pull/27
 .. _`#41`: https://github.com/robotics-in-concert/rocon_msgs/issue/41

--- a/scheduler_msgs/CMakeLists.txt
+++ b/scheduler_msgs/CMakeLists.txt
@@ -27,7 +27,8 @@ add_message_files(
   FILES
   AllocateResources.msg
   Request.msg
-  SchedulerFeedback.msg)
+  SchedulerFeedback.msg
+  SchedulerRequests.msg)
 
 generate_messages(DEPENDENCIES ${${PROJECT_NAME}_MSG_DEPENDENCIES})
 

--- a/scheduler_msgs/msg/AllocateResources.msg
+++ b/scheduler_msgs/msg/AllocateResources.msg
@@ -1,5 +1,7 @@
 ### Allocate Resources
 #
+#   DEPRECATED: use SchedulerRequests instead.
+#
 #   Rocon services send this message on the scheduler's input topic to
 #   make or update their resource requests.  All resources they
 #   current have or desire will be included.

--- a/scheduler_msgs/msg/Request.msg
+++ b/scheduler_msgs/msg/Request.msg
@@ -29,6 +29,7 @@ uint8 RELEASING   = 7   # The requester wishes to release this
                         #   confirmed that the request is canceled
 uint8 RELEASED    = 8   # The resource has been released successfully
                         #   (Terminal State)
+uint8 RESERVED    = 9   # A request for a reservation at some future time
 
 time  availability      # Estimated time of availability (zero if unknown)
 

--- a/scheduler_msgs/msg/Request.msg
+++ b/scheduler_msgs/msg/Request.msg
@@ -31,7 +31,8 @@ uint8 RELEASED    = 8   # The resource has been released successfully
                         #   (Terminal State)
 uint8 RESERVED    = 9   # A request for a reservation at some future time
 
-time  availability      # Estimated time of availability (zero if unknown)
+time     availability   # Estimated time of availability (zero if unknown)
+duration hold_time      # Estimated hold time once allocated (zero if unknown)
 
 ##  A rocon platform information tuple describes the desired resource.
 #

--- a/scheduler_msgs/msg/SchedulerFeedback.msg
+++ b/scheduler_msgs/msg/SchedulerFeedback.msg
@@ -1,5 +1,7 @@
 ### Scheduler Feedback
 #
+#   DEPRECATED: use SchedulerRequests instead.
+#
 #   This message is sent to a requester whenever the status of some
 #   request it made has changed.
 #

--- a/scheduler_msgs/msg/SchedulerRequests.msg
+++ b/scheduler_msgs/msg/SchedulerRequests.msg
@@ -1,0 +1,16 @@
+### Scheduler Requests
+#
+#   Rocon services send this message on the scheduler's input topic to
+#   make or update their resource requests.  All resources they
+#   currently have or desire should be included.
+#
+#   If not all of the requested resources are immediately available,
+#   the scheduler will queue those requests and provide feedback using
+#   a message of the same type.  The requester should wait until
+#   feedback indicates the associated resources are available.  It may
+#   cancel some requests at any time via an new allocation message.
+#
+Header header                   # Time of this status, frame_id irrelevant
+uuid_msgs/UniqueID requester    # Requester identifier
+int16 priority                  # Requester's priority, possibly adjusted
+Request[] requests              # Status of every currently-known request


### PR DESCRIPTION
This version retains all the old messages, although they are _deprecated_. We can remove the deprecated messages when everything using them is updated.

The API is backwards compatible, so it _should_ be safe to merge. There are new fields and constants, so the MD5 checksum will change, forcing recompilation.

Changes:
- add new `SchedulerRequests` message type 
- deprecate `AllocateResources` and `SchedulerFeedback` 
- add new `RESERVED` status to `Request` message 
- add `hold_time` duration to `Request` message
