### PR TITLE
scheduler_msgs: minor cleanup for hydro-devel branch

### DIFF
--- a/scheduler_msgs/CHANGELOG.rst
+++ b/scheduler_msgs/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Change history
 ==============
 
-0.6.3 (forthcoming)
--------------------
+(forthcoming)
+-------------
 
  * Initial version of an experimental scheduler message package for
    Hydro (`#27`_).

--- a/scheduler_msgs/CHANGELOG.rst
+++ b/scheduler_msgs/CHANGELOG.rst
@@ -12,6 +12,7 @@ Change history
    - add new RESERVED status to Request message
    - add hold_time duration to Request message
  * Add priority to Request message (`#43`_).
+ * Removed unneeded dependency on ``concert_msgs``.
 
 .. _`#27`: https://github.com/robotics-in-concert/rocon_msgs/pull/27
 .. _`#41`: https://github.com/robotics-in-concert/rocon_msgs/issues/41

--- a/scheduler_msgs/CMakeLists.txt
+++ b/scheduler_msgs/CMakeLists.txt
@@ -10,7 +10,6 @@ project(scheduler_msgs)
 ##############################################################################
 
 set(${PROJECT_NAME}_MSG_DEPENDENCIES
-    concert_msgs
     rocon_std_msgs
     std_msgs
     uuid_msgs)

--- a/scheduler_msgs/package.xml
+++ b/scheduler_msgs/package.xml
@@ -18,13 +18,11 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>message_generation</build_depend>
-  <build_depend>concert_msgs</build_depend>
   <build_depend>rocon_std_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>uuid_msgs</build_depend>
 
   <run_depend>message_runtime</run_depend>
-  <run_depend>concert_msgs</run_depend>
   <run_depend>rocon_std_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>uuid_msgs</run_depend>

--- a/scheduler_msgs/package.xml
+++ b/scheduler_msgs/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>scheduler_msgs</name>
-  <version>0.6.2</version>
+  <version>0.7.0</version>
   <description>
     Messages used by the rocon scheduler.
   </description>


### PR DESCRIPTION
Fix minor problems discovered while back-porting to hydro branch, see: #57.
- remove unneeded dependency on concert_msgs
- make package version agree with rest of hydro_devel rocon_msgs
