### PR TITLE
scheduler_msgs: backport Request revisions to Hydro (#60)

### DIFF
--- a/scheduler_msgs/CHANGELOG.rst
+++ b/scheduler_msgs/CHANGELOG.rst
@@ -1,19 +1,41 @@
 Change history
 ==============
 
+0.6.6 (forthcoming)
+-------------------
+
+ * Revise status labels, removing old ones (`#60`_):
+    - ABORTED -> CLOSED
+    - REJECTED -> CLOSED
+    - RELEASING -> CANCELING
+    - RELEASED -> CLOSED
+ * Add ``reason`` field with associated labels (`#60`_):
+    - NONE: no reason provided
+    - PREEMPTED: preempted for higher-priority task
+    - BUSY: requested resource busy elsewhere
+    - UNAVAILABLE: requested resource not available
+    - TIMEOUT: lost contact with requester
+ * Define more priority labels:
+    - BACKGROUND_PRIORITY: when nothing else to do
+    - LOW_PRIORITY: low-priority task
+    - DEFAULT_PRIORITY: sane default priority
+    - HIGH_PRIORITY: high-priority task
+    - CRITICAL_PRIORITY: mission-critical task
+
 0.6.5 (2013-12-19)
 ------------------
 
  * Initial version of an experimental scheduler message package for
    Hydro (`#27`_).
  * Updates due to experience with prototype implementation (`#41`_):
-   - add new SchedulerRequests message type
-   - deprecate AllocateResources and SchedulerFeedback
-   - add new RESERVED status to Request message
-   - add hold_time duration to Request message
+    - add new SchedulerRequests message type
+    - deprecate AllocateResources and SchedulerFeedback
+    - add new RESERVED status to Request message
+    - add hold_time duration to Request message
  * Add priority to Request message (`#43`_).
  * Removed unneeded dependency on ``concert_msgs``.
 
 .. _`#27`: https://github.com/robotics-in-concert/rocon_msgs/pull/27
 .. _`#41`: https://github.com/robotics-in-concert/rocon_msgs/issues/41
 .. _`#43`: https://github.com/robotics-in-concert/rocon_msgs/issues/43
+.. _`#60`: https://github.com/robotics-in-concert/rocon_msgs/issues/60

--- a/scheduler_msgs/msg/Request.msg
+++ b/scheduler_msgs/msg/Request.msg
@@ -1,59 +1,54 @@
 ### Resource request description
 #
 #   This tracks the progress of a single requested resource group.
-#
-#   QUESTION: do we need to track each request time separately?
-#
+#   All these resources will be granted, preempted or canceled
+#   together as a unit.
+
 ##############################################################################
 # Resource Identification
 ##############################################################################
 
-# This is usually a uniquely identifying ros_package/rapp name identifier.
-# This is unique because ros packages are necessarily unique. 
-Resource[] resources
-uuid_msgs/UniqueID id   # Requester-assigned unique identifier
-
-##############################################################################
-# Constants
-##############################################################################
-
-# We might like to apply some broader priority classifications via constants
-# (e.g. background, default, high, critical) for simplified usage
-int16 DEFAULT_PRIORITY = 0  # A sane default for priorities
+uuid_msgs/UniqueID id   # Requester-assigned universally unique identifier
+Resource[] resources    # List of requested rapps and platforms
 
 ##############################################################################
 # State
 ##############################################################################
 
-##  Status values are similar to actionlib goal states.
-#   NOTE: still likely to change.
-#
 uint8 status            # Current status of this request
+uint8 reason            # Reason for this status
 
-uint8 NEW         = 0   # A new request for the scheduler
-uint8 WAITING     = 1   # The request has been queued by the scheduler
-uint8 GRANTED     = 2   # The request was granted by the scheduler
-uint8 PREEMPTED   = 3   # The scheduler preempted this previously-
-                        #   granted request (Terminal State)
-uint8 ABORTED     = 4   # The request was aborted by the scheduler due
-                        #   to some failure (Terminal State)
-uint8 REJECTED    = 5   # The request was rejected by the scheduler
-                        #   without being processed, because it was
-                        #   unattainable or invalid (Terminal State)
-uint8 PREEMPTING  = 6   # The scheduler wants to preempt this
+#  Status value labels:
+uint8 NEW         = 0   # New request for the scheduler
+uint8 RESERVED    = 1   # Request for a reservation at some future time
+uint8 WAITING     = 2   # Request has been queued by the scheduler
+uint8 GRANTED     = 3   # Request was granted by the scheduler
+uint8 PREEMPTING  = 4   # The scheduler wants to preempt this
                         #   previously-granted request, but the
-                        #   requester has not yet released it
-uint8 RELEASING   = 7   # The requester wishes to release this
-                        #   resource, but the scheduler has not yet
-                        #   confirmed that the request is canceled
-uint8 RELEASED    = 8   # The resource has been released successfully
-                        #   (Terminal State)
-uint8 RESERVED    = 9   # A request for a reservation at some future time
+                        #   requester has not yet canceled it
+uint8 CANCELING   = 5   # The requester wishes to cancel this
+                        #   request, but the scheduler has not yet
+                        #   confirmed that it is closed
+uint8 CLOSED      = 6   # Request is now closed (terminal state)
+
+# Reason labels:
+uint8 NONE        = 0   # No reason provided
+uint8 PREEMPTED   = 1   # Preempted for higher-priority task
+uint8 BUSY        = 2   # Requested resource busy elsewhere
+uint8 UNAVAILABLE = 3   # Requested resource not available
+uint8 TIMEOUT     = 4   # Lost contact with requester
 
 ##############################################################################
 # Scheduling Variables
 ##############################################################################
 
-int16    priority       # current priority of this request
 time     availability   # Estimated time of availability (zero if unknown)
 duration hold_time      # Estimated hold time once allocated (zero if unknown)
+int16    priority       # Current priority of this request
+
+# Priority labels:
+int16 BACKGROUND_PRIORITY = -20000      # When nothing else to do
+int16 LOW_PRIORITY = -10000             # Low-priority task
+int16 DEFAULT_PRIORITY = 0              # Sane default priority
+int16 HIGH_PRIORITY = 10000             # High-priority task
+int16 CRITICAL_PRIORITY = 20000         # Mission-critical task


### PR DESCRIPTION
This is _not_ backwards compatible, but there should not be any Hydro users of this package, except me.

Releasing this version to Hydro will allow me to remove some annoying backwards compatibility code from rocon_scheduler_requests (utexas-bwi/rocon_scheduler_requests#21).

See also: #65
