### PR TITLE
scheduler_msgs: add CurrentStatus and KnownResources messages, with updates for new URI syntax

### DIFF
--- a/scheduler_msgs/CMakeLists.txt
+++ b/scheduler_msgs/CMakeLists.txt
@@ -24,6 +24,8 @@ find_package(catkin REQUIRED
 add_message_files(
   DIRECTORY msg
   FILES
+  CurrentStatus.msg
+  KnownResources.msg
   Request.msg
   Resource.msg
   SchedulerRequests.msg)

--- a/scheduler_msgs/msg/CurrentStatus.msg
+++ b/scheduler_msgs/msg/CurrentStatus.msg
@@ -1,0 +1,40 @@
+### ROCON resource current status.
+#
+#   A ROCON scheduler uses this message to report the status of each
+#   single resource it manages.
+#
+
+##############################################################################
+# Resource Identification
+##############################################################################
+
+#   Canonical ROCON identifier for this specific resource, typically a
+#   fully-resolved URI in the form:
+#
+#      rocon:///os/version/system/platform/name
+#
+string platform_info
+
+##############################################################################
+# Status
+##############################################################################
+
+uint8 status            # Current status of this resource
+
+#  Status value labels:
+uint8 AVAILABLE   = 0   # Available for use
+uint8 ALLOCATED   = 1   # Allocated to some ROCON request
+uint8 MISSING     = 2   # Not currently responding
+
+#   The owner is the unique identifier of the Request message to which
+#   this resource is currently assigned, or a zero UUID if it is not
+#   assigned.  An AVAILABLE resource never has an owner, but a MISSING
+#   one might.
+uuid_msgs/UniqueID owner
+
+#   List of ROCON application names currently available with this
+#   resource. The name string is usually a "ros_package/rapp"
+#   identifier, unique because ros package names are unique.  The
+#   contents of this list could change over time due to the device's
+#   own activities.
+string[] rapps

--- a/scheduler_msgs/msg/CurrentStatus.msg
+++ b/scheduler_msgs/msg/CurrentStatus.msg
@@ -1,19 +1,19 @@
 ### ROCON resource current status.
 #
 #   A ROCON scheduler uses this message to report the status of each
-#   single resource it manages.
+#   resource it manages.
 #
 
 ##############################################################################
 # Resource Identification
 ##############################################################################
 
-#   Canonical ROCON identifier for this specific resource, typically a
-#   fully-resolved URI in the form:
+#   A canonical ROCON Uniform Resource Identifier describing this
+#   resource, a fully-resolved character string in the form:
 #
-#      rocon:///os/version/system/platform/name
+#      rocon:/platform/name/framework/os
 #
-string platform_info
+string uri
 
 ##############################################################################
 # Status

--- a/scheduler_msgs/msg/KnownResources.msg
+++ b/scheduler_msgs/msg/KnownResources.msg
@@ -1,0 +1,7 @@
+### Known resources.
+#
+#   A ROCON scheduler uses this message to report the status of all
+#   the resources it knows about and manages.
+#
+Header header                   # Time of this status, frame_id irrelevant
+CurrentStatus[] resources       # Status of every currently-known resource

--- a/scheduler_msgs/msg/Resource.msg
+++ b/scheduler_msgs/msg/Resource.msg
@@ -1,27 +1,40 @@
+### ROCON resource request or response.
+#
+#   A scheduler_msgs/Request message includes one Resource message for
+#   each desired resource.  The scheduler responds using this same
+#   message to identify exactly what corresponding resource it has
+#   granted.
 
-# This is usually a uniquely identifying ros_package/rapp name identifier.
-# This is unique because ros packages are necessarily unique. 
-string name
+# This is usually a uniquely identifying ros_package/rapp name
+# identifier, which is unique because ros packages are unique.
+string rapp
 
-# unique identifier to help custom requesters keep a tab on resources
-# in the scheduler feedback.
+# Unique identifier assigned by the requester to track resources
+# assigned in the scheduler feedback.
 uuid_msgs/UniqueID id
 
-##############################################################################
-# Hints
-##############################################################################
-
-# Rocon URI. This is used in two ways by the scheduler:
+# Uniform Resource Identifier for the platform.  ROCON defines two
+# kinds of URI strings:
 #
-# 1) When used as part of a scheduler Request, it acts as a filter, 
-#    e.g. rocon://turtlebot/dude would lock it completely down,
-#    even to the name applied to the robot. Wildcards, such as '*' are
-#    acceptable.
-# 2) When used as part of a scheduler Reply, it contains the rocon uri
-#    of the concert client allocated. This is the platform_info.tuple
-#    of the concert client itself, with the name part swapped out for the
-#    unique concert name provided for the concert client client.
-
+# 1) A "resource description URI" is a canonical string for a specific
+#    device.  All components are fully resolved to their most specific
+#    values, like:
+#
+#      "rocon:/turtlebot/dude3/hydro/precise"
+#
+#    The scheduler provides fully resolved resource description URIs
+#    in its feedback for requests that have been granted.
+#
+# 2) A "request URI" may provide a similar descriptive representation,
+#    or may include patterns for matching multiple alternative
+#    platforms.  Omitted or '*' patterns match any valid value:
+#
+#      ""                               # (empty string): any platform
+#      "rocon:/turtlebot"               # any turtlebot
+#      "rocon:/(turtlebot|segbot)"      # any robot of either type
+#      "rocon:/*/dude3"                 # any device named dude3
+#      "rocon:/*/*/ros/ubuntu"          # any ROS Ubuntu platform
+#
 string uri
 
 # Remappings which get passed on for starting the rapps. Also potentially for


### PR DESCRIPTION
Not necessary to actually apply all of this PR. 

It mainly serves as a concrete example for the URI discussion (robotics-in-concert/rocon#7).

I would like to add the CurrentStatus and KnownResources messages some time soon, however.
