### PR TITLE
Export architecture_independent flag in package.xml

### DIFF
--- a/concert_msgs/package.xml
+++ b/concert_msgs/package.xml
@@ -30,5 +30,8 @@
   <run_depend>rocon_std_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>uuid_msgs</run_depend>
-  
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/concert_service_msgs/package.xml
+++ b/concert_service_msgs/package.xml
@@ -18,4 +18,8 @@
 
   <run_depend>message_runtime</run_depend>
   <run_depend>rocon_service_pair_msgs</run_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/gateway_msgs/package.xml
+++ b/gateway_msgs/package.xml
@@ -25,5 +25,8 @@
 
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
-  
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/rocon_app_manager_msgs/package.xml
+++ b/rocon_app_manager_msgs/package.xml
@@ -23,4 +23,8 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>rocon_std_msgs</run_depend>
   <run_depend>rocon_service_pair_msgs</run_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/rocon_device_msgs/package.xml
+++ b/rocon_device_msgs/package.xml
@@ -19,5 +19,8 @@
 
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
-  
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/rocon_interaction_msgs/package.xml
+++ b/rocon_interaction_msgs/package.xml
@@ -20,4 +20,8 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>rocon_std_msgs</run_depend>
   <run_depend>uuid_msgs</run_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/rocon_service_pair_msgs/package.xml
+++ b/rocon_service_pair_msgs/package.xml
@@ -20,5 +20,8 @@
   <run_depend>rospy</run_depend>
   <run_depend>uuid_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
-  
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/rocon_std_msgs/package.xml
+++ b/rocon_std_msgs/package.xml
@@ -21,4 +21,8 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>rocon_service_pair_msgs</run_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/rocon_tutorial_msgs/package.xml
+++ b/rocon_tutorial_msgs/package.xml
@@ -18,4 +18,8 @@
 
   <run_depend>message_runtime</run_depend>
   <run_depend>rocon_service_pair_msgs</run_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/scheduler_msgs/package.xml
+++ b/scheduler_msgs/package.xml
@@ -26,5 +26,8 @@
   <run_depend>rocon_std_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>uuid_msgs</run_depend>
-  
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>


### PR DESCRIPTION
This package doesn't have any binaries in it, so it can be marked as architecture independent.

Tested on the RPM buildfarm (http://csc.mcs.sdsmt.edu/jenkins/):
- [x] No regressions
- [x] No binaries installed

See:
- https://github.com/ros/rosdistro/issues/4037
- https://github.com/ros-infrastructure/bloom/pull/270
- http://www.ros.org/reps/rep-0127.html#architecture-independent

Thanks!
